### PR TITLE
Sync with a dnsdbq change

### DIFF
--- a/dnsdbflex.c
+++ b/dnsdbflex.c
@@ -483,7 +483,7 @@ help(void) {
 #endif
 	puts("\nGetting Started:\n"
 	     "\tAdd your API key to ~/.dnsdb-query.conf like this:\n"
-	     "\t\tAPIKEY=\"YOURAPIKEYHERE\"");
+	     "\t\tDNSDB_API_KEY=\"YOURAPIKEYHERE\"");
 	printf("\nTry $ man %s for full documentation.\n", program_name);
 }
 
@@ -632,7 +632,7 @@ read_configs(void) {
 			     ". %s;"
 			     "echo dnsdbq system $" DNSDBQ_SYSTEM ";"
 #if WANT_PDNS_DNSDB2
-			     "echo dnsdb2 apikey $APIKEY;"
+			     "echo dnsdb2 apikey ${DNSDB_API_KEY:-$APIKEY};"
 			     "echo dnsdb2 server $DNSDB_SERVER;"
 #endif
 			     "exit", cf);


### PR DESCRIPTION
Require API key passed in $DNSDB_API_KEY environment variable if not in the config file as APIKEY or DNSDB_API_KEY. 
Allow DNSDB_API_KEY in config file instead of APIKEY.

My ~/.dnsdb-query.conf file that works fine with a recent dnsdbq would not work without this.