### PR TITLE
Can now build on Apple M1 processors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 by Farsight Security, Inc.
+# Copyright (c) 2020-2022 by Farsight Security, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,19 @@
 # limitations under the License.
 #
 
-CURLINCL = `curl-config --cflags` 
-JANSINCL = -I/usr/local/include
+# Base directory for jansson header and libraries
+JANSBASE=/usr/local
+# For macOS on M1, use this instead of the above line:
+#JANSBASE=/opt/homebrew
 
+JANSINCL = -I$(JANSBASE)/include
+
+JANSLIBS = -L$(JANSBASE)/lib -ljansson
+# For almost static builds on macOS, use this instead of the above line:
+#JANSLIBS = $(JANSBASE)/lib/libjansson.a
+
+CURLINCL = `curl-config --cflags`
 CURLLIBS = `[ ! -z "$$(curl-config --libs)" ] && curl-config --libs || curl-config --static-libs`
-JANSLIBS = -L/usr/local/lib -ljansson
 
 CWARN =-W -Wall -Wextra -Wcast-qual -Wpointer-arith -Wwrite-strings \
 	-Wmissing-prototypes  -Wbad-function-cast -Wnested-externs \
@@ -30,7 +38,7 @@ CWARN   +=-Werror
 
 CDEFS = -DWANT_PDNS_DNSDB2=1
 CGPROF =
-CDEBUG = -g
+CDEBUG = -g -O3
 CFLAGS += $(CGPROF) $(CDEBUG) $(CWARN) $(CDEFS)
 
 TOOL = dnsdbflex

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2021 by Farsight Security, Inc.
+ * Copyright (c) 2014-2022 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ Table of Contents:
 
 Introduction:
 
-    dnsdbflex is a pure C99 program that accesses passive DNS database systems such as:
+    dnsdbflex is a pure C99 program that accesses passive DNS database systems
+    such as:
         * the DNSDB Flex API server at Farsight Security
 
     An API key is required for operation.
@@ -87,26 +88,33 @@ Building and installing:
     cd dnsdbflex
     make install clean
 
+    On macOS on Apple M1 processors, Homebrew now defaults to be
+    installed in /opt/homebrew instead of /usr/local.  If that is the
+    case on your system, in the Makefile, uncomment the line
+    #JANSBASE=/opt/homebrew
+
     On macOS, if you want an almost static dnsdbflex binary on macOS,
     that is, one without any non-System library dependencies, you can
     rebuild dnsdbflex with a static jansson library.  That binary could
     then be deployed on any identical macOS version and architecture.
 
-	1. Find the static jansson library, probably
-	   /usr/local/lib/libjansson.a as installed by brew.
+	1. Find the static jansson library, probably as installed by brew
+	   /usr/local/lib/libjansson.a or /opt/homebrew/lib/libjansson.a
 	2. Change the Makefile's line
-		JANSLIBS = -L/usr/local/lib -ljansson
+		JANSLIBS = -L$(JANSBASE)/lib -ljansson
 	    to instead specify the static library location, probably to:
-		JANSLIBS = /usr/local/lib/libjansson.a
+		JANSLIBS = $(JANSBASE)/lib/libjansson.a
 	3. Then run make
 
 Getting Started:
     Add the API key to ~/.dnsdb-query.conf in the below given format,
     DNSDB_API_KEY="YOURAPIKEYHERE"
 
-    If you don't have an API key, you may qualify for a free one:
-    https://www.farsightsecurity.com/dnsdb-community-edition/
-
+    If you're interested in purchasing a Farsight DNSDB subscription,
+    please contact sales@farsightsecurity.com.  Farsight also has a
+    grant program for selected researchers, investigative journalists,
+    and cybersecurity workers at some public benefit non-profits.
+    See https://www.farsightsecurity.com/grant-access/
 
 Optional Filter Scripts:
 


### PR DESCRIPTION
 by following the instructions in the README for modifying the Makefile.

* Default to -O3 compilation.
* Remove reference to DNSDB community edition.