### PR TITLE
sync latest dnsdbq changes to dnsdbflex: curl timeout option

### DIFF
--- a/dnsdbflex.man
+++ b/dnsdbflex.man
@@ -25,6 +25,7 @@
 .Op Cm --glob Ar glob
 .Op Cm --mode Ar terse
 .Op Cm --regex Ar regular_expression
+.Op Cm --timeout Ar timeout
 .Op Fl A Ar timestamp
 .Op Fl B Ar timestamp
 .Op Fl l Ar query_limit
@@ -129,6 +130,10 @@ Specify that
 .Nm dnsdbflex
 should do a regular expression search in the FCRE syntax.  Can abbreviate as
 .Ic --r .
+
+.It Cm --timeout Ar timeout
+Specify the timeout, in seconds, for the initial connection to the database server and for each subsequent transaction. 0 means no timeout.
+
 .It Fl A Ar timestamp
 Specify a backward time fence. Only results seen by the passive DNS
 sensor network on or after this time will be selected. See also
@@ -364,6 +369,10 @@ contains the URL of the DNSDB API server, and optionally a URI prefix to be
 used. If not set, the configuration file is consulted.
 .It Ev DNSDBQ_SYSTEM
 See DNSDBQ_SYSTEM in the FILES section above.
+.It Ev DNSDBFLEX_TIMEOUT
+Specify the timeout (in seconds) to use for network requests. An alternative to passing
+.Ic --timeout <seconds>
+on the command line
 .El
 .Sh "EXIT STATUS"
 Success (exit status zero) occurs if a connection could be established

--- a/globals.h
+++ b/globals.h
@@ -30,6 +30,7 @@ EXTERN	const char id_version[]		INIT("1.0.6");
 EXTERN	const char *program_name	INIT(NULL);
 EXTERN	const char jsonl_header[]	INIT("Accept: application/x-ndjson");
 EXTERN	const char env_config_file[]	INIT("DNSDBQ_CONFIG_FILE");
+EXTERN	const char env_timeout[]	INIT("DNSDBFLEX_TIMEOUT");
 EXTERN	const char status_noerror[]	INIT("NOERROR");
 EXTERN	const char status_error[]	INIT("ERROR");
 EXTERN	pdns_system_ct psys		INIT(NULL);
@@ -41,6 +42,7 @@ EXTERN	present_t presenter		INIT(NULL);
 EXTERN	struct timeval startup_time	INIT({});
 EXTERN	int exit_code			INIT(0);
 EXTERN	long curl_ipresolve		INIT(CURL_IPRESOLVE_WHATEVER);
+EXTERN	long curl_timeout		INIT(0L);
 
 #undef INIT
 #undef EXTERN

--- a/netio.c
+++ b/netio.c
@@ -112,6 +112,13 @@ create_fetch(query_t query, char *url) {
 		curl_easy_setopt(fetch->easy,
 				 CURLOPT_IPRESOLVE, curl_ipresolve);
 
+	if (curl_timeout != 0L) {
+		curl_easy_setopt(fetch->easy,
+				 CURLOPT_CONNECTTIMEOUT, curl_timeout);
+		curl_easy_setopt(fetch->easy,
+				 CURLOPT_TIMEOUT, curl_timeout);
+	}
+
 	if (psys->auth != NULL)
 	    psys->auth(fetch);
 


### PR DESCRIPTION
1st pass at syncing latest dnsdbq changes to dnsdbflex: curl timeout option

author: by Moshe Waitzman <mwaitzman@outlook.com>